### PR TITLE
Pair byes to lowest players

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ Swissper.pair([snap, crackle, pop])
 
 Please don't manually pass in `Swissper::Bye` in your array of players, passing in an odd-length array is the correct way to use byes.
 
+### Bye delta
+
+Byes have a default delta of -1 by default, but you can override this with the `bye_delta` option.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/swissper.rb
+++ b/lib/swissper.rb
@@ -12,6 +12,7 @@ module Swissper
     def initialize(options = {})
       @delta_key = options[:delta_key] || :delta
       @exclude_key = options[:exclude_key] || :exclude
+      @bye_delta = options[:bye_delta] || -1
     end
 
     def pair(player_data)
@@ -23,7 +24,7 @@ module Swissper
 
     private
 
-    attr_reader :delta_key, :exclude_key
+    attr_reader :delta_key, :exclude_key, :bye_delta
 
     def graph
       edges = [].tap do |e|
@@ -50,6 +51,7 @@ module Swissper
 
     def delta_value(player)
       return player.send(delta_key) if player.respond_to?(delta_key)
+      return bye_delta if player == Swissper::Bye
 
       0
     end

--- a/lib/swissper/version.rb
+++ b/lib/swissper/version.rb
@@ -1,3 +1,3 @@
 module Swissper
-  VERSION = "0.2.0"
+  VERSION = "0.2.2"
 end

--- a/spec/swissper_spec.rb
+++ b/spec/swissper_spec.rb
@@ -73,6 +73,16 @@ RSpec.describe Swissper do
           expect(p).to match_array([pop, Swissper::Bye]) if p.include?(pop)
         end
       end
+
+      it 'always give bye to lowest players' do
+        snap.delta = 1
+        crackle.delta = 0
+        pop.delta = 0
+
+        paired.each do |p|
+          expect(p).not_to match_array([snap, Swissper::Bye]) if p.include?(Swissper::Bye)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Byes need a default delta of -1 to avoid being weighted equally with players on 0 (and therefore possibly being paired up over these players).

This bye delta can be overridden via an option